### PR TITLE
container class use config option value

### DIFF
--- a/source/slides.jquery.js
+++ b/source/slides.jquery.js
@@ -27,7 +27,7 @@
 			$('.' + option.container, $(this)).children().wrapAll('<div class="slides_control"/>');
 			
 			var elem = $(this),
-				control = $('.slides_control',elem),
+				control = $('.' + option.container,elem),
 				total = control.children().size(),
 				width = control.children().outerWidth(),
 				height = control.children().outerHeight(),


### PR DESCRIPTION
the container class should use the config option value like line 27
$('.' + option.container, $(this)).children().wrapAll('<div class="slides_control"/>');

control = $('.slides_control',elem),